### PR TITLE
Supports TS 3.1

### DIFF
--- a/extractor.ts
+++ b/extractor.ts
@@ -52,15 +52,15 @@ export function extract(paths: string[], opts?: Partial<Options>) {
   return opts.asJsonString ? JSON.stringify(info, null, 2) : info;
 }
 
-function isWritable(node: ts.Node) {
+function isWritable(node: ts.Declaration) {
   return (ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Readonly) === 0;
 }
 
-function isExported(node: ts.Node) {
+function isExported(node: ts.Declaration) {
   return (ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export) === 1;
 }
 
-function isPublic(node: ts.Node) {
+function isPublic(node: ts.Declaration) {
   const flags = ts.getCombinedModifierFlags(node);
   return (
       (flags & ts.ModifierFlags.Private) === 0 &&

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@types/mustache": "^0.8.30",
     "@types/node": "^9.4.6",
     "mustache": "^2.3.0",
-    "typescript": "^2.7.2",
+    "typescript": "^3.1.6",
     "yargs": "^11.0.0"
   },
   "devDependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,9 +235,10 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-typescript@^2.7.2:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
After this change, the generated Python script is:

```py
"""HelloWorld proxy."""

from google.colab import html

class HelloWorld(html.Element):
  """undefined method."""

  def __init__(self):
    super(HelloWorld, self).__init__('hello-world')

  def say_hi(self, name):
    """sayHi method."""
    self._call('sayHi', name)

```